### PR TITLE
hpy 0.0.4 and c++

### DIFF
--- a/Cython/Compiler/Backend.py
+++ b/Cython/Compiler/Backend.py
@@ -581,7 +581,13 @@ class CombinedBackend(APIBackend):
         code.putln("#define __PYX_NONE %s" % CApiBackend.pynone)
         code.putln("#define __PYX_NONE_NEW %s" % CApiBackend.get_none())
         for k in CombinedBackend.hpy_functions:
-            code.putln("#define %s %s" % (CombinedBackend.hpy_functions[k], CApiBackend.py_functions[k]))
+            code.putln("#define %s %s" % (
+                CombinedBackend.hpy_functions[k], CApiBackend.py_functions[k],
+            ))
+            code.putln("#define %s %s" % (
+                CombinedBackend.get_binary_operation_function(k, True),
+                CApiBackend.get_binary_operation_function(k, True),
+            ))
         CApiBackend.put_init_code(code)
 
         code.putln("#else /* %s */" % hpy_guard)
@@ -628,7 +634,14 @@ class CombinedBackend(APIBackend):
         code.putln("#define __PYX_NONE %s" % HPyBackend.pynone)
         code.putln("#define __PYX_NONE_NEW %s" % HPyBackend.get_none())
         for k in CombinedBackend.hpy_functions:
-            code.putln("#define %s %s" % (CombinedBackend.hpy_functions[k], HPyBackend.hpy_functions[k]))
+            code.putln("#define %s %s" % (
+                CombinedBackend.hpy_functions[k],
+                HPyBackend.hpy_functions[k],
+            ))
+            code.putln("#define %s %s" % (
+                CombinedBackend.get_binary_operation_function(k, True),
+                HPyBackend.get_binary_operation_function(k, True),
+            ))
         code.putln("#endif /* %s */" % hpy_guard)
 
     @staticmethod

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2314,7 +2314,7 @@ class CCodeWriter(object):
     def put_init_to_py_none(self, cname, type, nanny=True):
         from .PyrexTypes import py_object_type, typecast
         py_none = typecast(type, py_object_type, backend.pynone)
-        self.putln("%s = %s; %s;" % (cname, py_none, backend.get_newref(py_none, nanny=nanny)))
+        self.putln("%s = %s;" % (cname, backend.get_newref(py_none, nanny=nanny)))
 
     def put_init_var_to_py_none(self, entry, template = "%s", nanny=True):
         code = template % entry.cname

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1520,7 +1520,7 @@ class GlobalState(object):
             UtilityCode.load_cached("GetBuiltinName", "ObjectHandling.c"))
         from .PyrexTypes import py_object_type
         tmp_var = w.funcstate.allocate_temp(py_object_type, True)
-        w.putln('%s = %s; if (!%s) %s' % (
+        w.putln('%s = %s; if (%s) %s' % (
             tmp_var,
             backend.get_call('__Pyx_GetBuiltinNameFromGlobal', interned_cname),
             backend.get_is_null_cond(tmp_var),

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3058,33 +3058,39 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("#endif")
 
         code.putln("/* initialise %s */" % Naming.empty_tuple)
+        code.putln("{")
         tmp_empty_tuple_cname = Naming.temp_prefix + "empty_tuple"
-        code.putln("%s tuple_builder = %s;" % (
+        code.putln("  %s tuple_builder = %s;" % (
             backend.tuple_builder_ctype, backend.get_call(backend.tuple_builder_new, "0")))
-        code.putln("%s %s = %s; %s" % (
+        code.putln("  %s %s = %s; %s" % (
             backend.pyobject_ctype, tmp_empty_tuple_cname,
             backend.get_call(backend.tuple_builder_build, "tuple_builder"),
             code.error_goto_if_null(tmp_empty_tuple_cname, self.pos)))
-        code.putln("%s;" % backend.get_write_global(env.module_cname, Naming.empty_tuple, tmp_empty_tuple_cname))
-        code.putln("%s;" % backend.get_closeref(tmp_empty_tuple_cname, False, False))
+        code.putln("  %s;" % backend.get_write_global(env.module_cname, Naming.empty_tuple, tmp_empty_tuple_cname))
+        code.putln("  %s;" % backend.get_closeref(tmp_empty_tuple_cname, False, False))
+        code.putln("}")
 
         tmp_empty_bytes_cname = Naming.temp_prefix + "empty_bytes"
         code.putln("/* initialise %s */" % Naming.empty_bytes)
-        code.putln("%s %s = %s; %s" % (
+        code.putln("{")
+        code.putln("  %s %s = %s; %s" % (
             backend.pyobject_ctype, tmp_empty_bytes_cname,
             backend.get_call(backend.bytes_from_string_and_size, "\"\"", "0"),
             code.error_goto_if_null(tmp_empty_bytes_cname, self.pos)))
-        code.putln("%s;" % backend.get_write_global(env.module_cname, Naming.empty_bytes, tmp_empty_bytes_cname))
-        code.putln("%s;" % backend.get_closeref(tmp_empty_bytes_cname, False, False))
+        code.putln("  %s;" % backend.get_write_global(env.module_cname, Naming.empty_bytes, tmp_empty_bytes_cname))
+        code.putln("  %s;" % backend.get_closeref(tmp_empty_bytes_cname, False, False))
+        code.putln("}")
 
         tmp_empty_unicode_cname = Naming.temp_prefix + "empty_unicode"
         code.putln("/* initialise %s */" % Naming.empty_unicode)
-        code.putln("%s %s = %s; %s" % (
+        code.putln("{")
+        code.putln("  %s %s = %s; %s" % (
             backend.pyobject_ctype, tmp_empty_unicode_cname,
             backend.get_call(backend.unicode_from_string, "\"\""),
             code.error_goto_if_null(tmp_empty_unicode_cname, self.pos)))
-        code.putln("%s;" % backend.get_write_global(env.module_cname, Naming.empty_unicode, tmp_empty_unicode_cname))
-        code.putln("%s;" % backend.get_closeref(tmp_empty_unicode_cname, False, False))
+        code.putln("  %s;" % backend.get_write_global(env.module_cname, Naming.empty_unicode, tmp_empty_unicode_cname))
+        code.putln("  %s;" % backend.get_closeref(tmp_empty_unicode_cname, False, False))
+        code.putln("}")
 
         # TODO(fa): currently not supported with the HPy backend
         code.putln("#if !(%s)" % backend.hpy_guard)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3591,6 +3591,7 @@ class DefNodeWrapper(FuncDefNode):
             code.put_label(code.error_label)
             for cname, type in code.funcstate.all_managed_temps():
                 code.put_xdecref(cname, type)
+                code.funcstate.release_temp(cname)
             err_val = self.error_value()
             if err_val is not None:
                 code.putln("%s = %s;" % (Naming.retval_cname, err_val))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 numpy
 coverage
 pycodestyle
-git+https://github.com/hpyproject/hpy.git@0.0.3
+hpy==0.0.4

--- a/tests/memoryview/extension_type_memoryview.pyx
+++ b/tests/memoryview/extension_type_memoryview.pyx
@@ -22,7 +22,7 @@ def test_getitem():
     """
     for i in range(view.shape[0]):
         item = view[i]
-        print item.dummy
+        print(item.dummy)
 
 def test_getitem_typed():
     """
@@ -33,4 +33,4 @@ def test_getitem_typed():
     cdef ExtensionType item
     for i in range(view.shape[0]):
         item = view[i]
-        print item.dummy
+        print(item.dummy)


### PR DESCRIPTION
this PR
- updates the version of hpy used in tests to 0.0.4
- fixes the code generation to avoid an error in c++ where a `goto` crosses variable initialization. The fix is to enclose the code in braces